### PR TITLE
add: rulefiles, more tests, updated ruleformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # Change Log
 
+## 2.0
+* Changed the rule format.
+  rules are now defined as an object {"rule": ()=>{}} 
+  This is a breaking change on the plugin behavior and the consuming data, this means mayor bump version.
+
+* Added rule file for config.
+  Now can pass external rulefiles to add multiple rules to the parser.
+
+* Added more tests.
+  Now test cover the following cases:
+  * uses multiple custom convert function and units
+  * import file, uses rules from imported file
+  * import file, uses rules from imported file and merge with current rules
+  * works with nested rules
+  * works with nested rule with shared name
+  * converts to css vars
+  * converts to css vars with shared name
+  * converts to css vars with value
+  * converts to css vars with css vars
+  * converts to css vars with css vars and values
+
+* Added test watch command
+  Now we can launch test in watch mode.
 ## 1.0
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -23,25 +23,34 @@ We can use this plugin to work directly with px units and translate to rem in bu
 
 ## Usage
 
+### Import postCSS
+
 Import the postCSS core
+
 ```typesecript
 import postcss from "https://deno.land/x/postcss@8.4.16/mod.js";
 ```
 
+### Define your set of rules
+
 Define the unit transforms as an array of transforms of the opts object, in the following way:
 ```typescript
 const opts = {
-  rules: [
-    { unitName: "--sp", convert: (val: number) => `${val * 0.25}rem` }
-  ],
+  rules: {
+    "1--sp", (val: number) => `${val * 0.25}rem`
+  }
 };
 ```
+
+### Add the plugin to postCSS pipe
 
 Add the plugin with the transforms the postcss process
 ```typescript
   const result = await postcss(
     [plugin(opts)]).process(input);
 ```
+
+### Results
 
 This will transform your css files from:
 ```css
@@ -53,6 +62,41 @@ To this.
 ```css
   /* Output css file */
   a{ margin: 1rem;}
+```
+
+
+## Anatomy of a rule
+### Rules format
+
+`rules` is an object in the form of "rule" to apply and a transform function to be set as output.
+
+### Rule definition
+
+The plugin will lok for every rule defined in the rules object and will replace the value with the returned value from the trans form function. The rule can store a number set on the rule string start, this value will be passed as a param to the transform function. In the following example the number 4 will be pased as val to the transform function.
+
+```typescript
+const opts = {
+  rules: {
+    "4--border", (val: number) => `${val * 0.25}rem`
+  }
+};
+```
+
+### Transform function
+
+The transform function optionaly receives a param `value: number` set on the rule start string.
+
+### Define Rules in config files
+
+You can define several rulefiles following the regular format, just import them as js files and pass it to the plugin.
+```typescript
+import importedRules from './rulefile.example.js';
+
+const opts = {
+  rules: {
+    ...importedRules,
+  }
+}
 ```
 ## License
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
     "test": "deno test --allow-env src/spec/index.spec.ts",
+    "test:watch": "deno test --watch --allow-env src/spec/index.spec.ts",
     "fmt": "deno fmt ./src/mod.ts",
     "bundle": "deno task fmt && deno bundle ./src/mod.ts ./src/mod.js"
   }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,16 +4,13 @@ import Declaration from "https://deno.land/x/postcss@8.4.16/lib/declaration.d.ts
 /**
  * type for transformation format
  */
-export type ruleType = {
-  unitName: string;
-  convert: (val: number) => string;
-};
+export type ruleType = Record<string, (((val: number) => string) | (() => string))>;
 
 /**
  * type for options passed to plugin
  */
 export interface optsType {
-  rules: ruleType[];
+  rules: ruleType;
 }
 
 /**
@@ -28,17 +25,26 @@ const plugin = (opts: optsType) => {
 
     Declaration: {
       "*": (decl: Declaration) => {
-        opts.rules.forEach(
-          (rule) => {
-            const regex = new RegExp(`(([\\d.]+)${rule.unitName})`, "g");
 
-            decl.value = decl.value.replace(
+        let str = decl.value;
+        // console.log(decl);
+
+        Object.entries(opts.rules).forEach(
+          ([key, value]) => {
+            // optionally a number followed by the key and not followed by any valid char more
+            const regex = new RegExp(`(([\\d.]+)?(${key})(?![a-zA-Z0-9_\-]))`, "g");
+
+            str = str.replace(
               regex,
-              (_match: string, _p1: string, p2: string) =>
-                rule.convert(parseInt(p2)),
+              (_match: string, _p1: string, _p2, _p3,_p4) => {
+
+                return value(parseInt(_p2));
+              }
             );
-          },
+          }
         );
+
+        decl.value = str;
       },
     },
   };

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.155.0/testing/asserts.ts";
 import postcss from "https://deno.land/x/postcss@8.4.16/mod.js";
 
+import importedRules from './rulefile.example.js';
 import plugin, { optsType } from "../mod.ts";
 
 /**
@@ -15,7 +16,7 @@ async function run(
   output: string,
   opts: optsType,
 ) {
-  const result = await postcss([plugin(opts)]).process(input);
+  const result = await postcss([plugin(opts)]).process(input, {from: undefined});
 
   assertEquals(result.css, output);
   assertEquals(result.warnings().length, 0);
@@ -26,20 +27,132 @@ Deno.test("uses custom convert function and units", async () => {
     "a{ margin: 4--pw;}",
     "a{ margin: 1rem;}",
     {
-      rules: [{ unitName: "--pw", convert: (val: number) => `${val * 0.25}rem` }],
+      rules: {"--pw": (val:number) => `${val * 0.25}rem` },
     },
   );
 });
 
 Deno.test("uses multiple custom convert function and units", async () => {
   await run(
-    "a{ margin: 1--sp 1sp;}",
-    "a{ margin: 0.25rem 1rem;}",
+    "a{ margin: 1--sp; padding: --xs;}",
+    "a{ margin: 0.25rem; padding: a complex string;}",
     {
-      rules: [
-        { unitName: "--sp", convert: (val: number): string => `${val * 0.25}rem` },
-        { unitName: "sp", convert: (val: number): string => `${val}rem` },
-      ],
+      rules: {
+        "--sp": (val: number): string => `${val * 0.25}rem` ,
+        "--xs": (): string => `a complex string` ,
+      },
+    },
+  );
+});
+
+Deno.test("import file, uses rules from imported file", async () => {
+  await run(
+    "a{ margin: 1--sp; padding: --xs;}",
+    "a{ margin: 0.25rem; padding: 1rem 1rem;}",
+    {
+      rules: {
+        ...importedRules,
+      },
+    },
+  );
+});
+
+Deno.test("import file, uses rules from imported file and merge with current rules", async () => {
+  await run(
+    "a{ margin: 1--sp; padding: --xs; border: --border;}",
+    "a{ margin: 0.25rem; padding: 1rem 1rem; border: 1px solid #000;}",
+    {
+      rules: {
+        "--border": (): string => `1px solid #000` ,
+        ...importedRules,
+      },
+    },
+  );
+});
+
+Deno.test("works with nested rules", async () => {
+  await run(
+    "a{border: --border;}",
+    "a{border: 3px solid #000;}",
+    {
+      rules: {
+        "--border": (): string => `3--sp solid #000` ,
+        "--sp": (val: number): string => `${val}px` ,
+      },
+    },
+  );
+});
+
+Deno.test("works with nested rule with shared name", async () => {
+  await run(
+    "a{border: --border;}",
+    "a{border: 3px solid #000;}",
+    {
+      rules: {
+        "--border": (): string => `3--border-xs solid #000` ,
+        "--border-xs": (val: number): string => `${val}px` ,
+      },
+    },
+  );
+});
+
+Deno.test("converts to css vars", async () => {
+  await run(
+    "a{margin: --margin;}",
+    "a{margin: var(--xs);}",
+    {
+      rules: {
+        "--margin": (): string => `var(--xs)`,
+      },
+    },
+  );
+});
+
+Deno.test("converts to css vars with shared name", async () => {
+  await run(
+    "a{margin: --margin;}",
+    "a{margin: var(--margin-xs);}",
+    {
+      rules: {
+        "--margin": (): string => `var(--margin-xs)`,
+      },
+    },
+  );
+});
+
+Deno.test("converts to css vars with value", async () => {
+  await run(
+    "a{border: --border;}",
+    "a{border: 4px solid #000;}",
+    {
+      rules: {
+        "--border": (): string => `1--sp solid #000` ,
+        "--sp": (val: number): string => `${val * 4}px` ,
+      },
+    },
+  );
+});
+
+Deno.test("converts to css vars with css vars", async () => {
+  await run(
+    "a{border: var(--border) 1px;}",
+    "a{border: var(--border-sp) 1px;}",
+    {
+      rules: {
+        "--border": (): string => `--border-sp`,
+      },
+    },
+  );
+});
+
+Deno.test("converts to css vars with css vars and values", async () => {
+  await run(
+    "a{border: var(--border) 1px;}",
+    "a{border: var(1--border-sp) 1px;}",
+    {
+      rules: {
+        "--border": (): string => `1--border-sp`,
+      },
     },
   );
 });

--- a/src/spec/rulefile.example.js
+++ b/src/spec/rulefile.example.js
@@ -1,0 +1,8 @@
+
+// Example set of rules to be passed to the plugin
+const rules = {
+  "--sp": val => `${val * 0.25}rem`,
+  "--xs": () => `1rem 1rem`
+}
+
+export default rules;


### PR DESCRIPTION
# Version Bump

## Changelog v2.0.0

* Changed the rule format.
  rules are now defined as an object {"rule": ()=>{}} 
  This is a breaking change on the plugin behavior and the consuming data, this means mayor bump version.

* Added rule file for config.
  Now can pass external rulefiles to add multiple rules to the parser.

* Added more tests.
  Now test cover the following cases:
  * uses multiple custom convert function and units
  * import file, uses rules from imported file
  * import file, uses rules from imported file and merge with current rules
  * works with nested rules
  * works with nested rule with shared name
  * converts to css vars
  * converts to css vars with shared name
  * converts to css vars with value
  * converts to css vars with css vars
  * converts to css vars with css vars and values

* Added test watch command
  Now we can launch test in watch mode.